### PR TITLE
Fix ansible dependency according to CVE-2019-3828

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.6.3
+ansible==2.6.14
 python-selvpcclient==1.0
 ipaddress==1.0.18

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=["ansible/modules/selvpc",
               "ansible/module_utils/selvpc_utils"],
     install_requires=[
-        'ansible==2.6.3',
+        'ansible==2.6.14',
         'python-selvpcclient==1.0'
     ],
 )


### PR DESCRIPTION
Vulnerable versions: >= 2.6.0, < 2.6.14
Patched version: 2.6.14
Ansible fetch module before versions 2.5.15, 2.6.14, 2.7.8 has
a path traversal vulnerability which allows copying and overwriting
files outside of the specified destination in the local ansible
controller host, by not restricting an absolute path.